### PR TITLE
Error creating new scheduled/periodic tasks on newer module versions

### DIFF
--- a/scheduler/models.py
+++ b/scheduler/models.py
@@ -75,7 +75,7 @@ class BaseJob(TimeStampedModel):
             })
 
     def is_scheduled(self):
-        return self.job_id in self.scheduler()
+        return self.job_id and self.job_id in self.scheduler()
     is_scheduled.short_description = _('is scheduled?')
     is_scheduled.boolean = True
 


### PR DESCRIPTION
This is related to the issue #32

It seems the comparator implementation for Scheduler class is not working as previous versions on rq_scheduler module. The current implementation:
```
    def __contains__(self, item):
        """
        Returns a boolean indicating whether the given job instance or job id
        is scheduled for execution.
        """
        job_id = item
        if isinstance(item, self.job_class):
            job_id = item.id
        return self.connection.zscore(self.scheduled_jobs_key, job_id) is not None
```
it seems that the member value when calling to zscrore cannot be nullable.